### PR TITLE
build: Bump MkDocs to v8.5.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-site
+/site/
+/.cache/
+/.vscode/

--- a/docs/stylesheets/navigation.css
+++ b/docs/stylesheets/navigation.css
@@ -2,33 +2,51 @@
 .md-header {
   background: #3A7CA5;
 }
-.md-nav--primary .md-nav__title[for=__drawer] {
-    background: var(--md-primary-fg-color--dark);
-    overflow: visible;
+
+.md-header__topic:first-child {
+  font-weight: 300;
 }
+
+.md-nav--primary .md-nav__title[for=__drawer] {
+  background: var(--md-primary-fg-color--dark);
+  overflow: visible;
+}
+
 .md-tabs {
   background: #2F6690;
 }
+
 .md-top {
   color: #ffffff;
 }
+
 .md-top {
   color: #ffffff;
 }
-.md-tabs__link--active, .md-tabs__link:focus, .md-tabs__link:hover {
+
+.md-tabs__link--active,
+.md-tabs__link:focus,
+.md-tabs__link:hover {
   border-bottom: 1.5px solid #D9DCD6;
   height: -webkit-fill-available;
 }
 
+.md-footer__title {
+  color: #ffffff;
+
+}
+
 /*Announcement Bar*/
 .md-banner {
-    background-color: var(--md-footer-bg-color--dark);
-    color: var(--md-footer-fg-color);
-    overflow: auto;
-    text-align: center;
+  background-color: var(--md-footer-bg-color--dark);
+  color: #ffffff;
+  overflow: auto;
+  text-align: center;
 }
-.md-typeset img, .md-typeset svg {
-    height: auto;
-    max-width: 100%;
-    vertical-align: text-bottom;
+
+.md-typeset img,
+.md-typeset svg {
+  height: auto;
+  max-width: 100%;
+  vertical-align: text-bottom;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 # Project Information
 site_name: VATNZ Standard Operating Procedures
-site_url: https://vatnz-dev.github.io/sops/
+site_description: Helpful information for people flying within the virtual New Zealand FIRs.
+site_url: http://sops.vatnz.net/
 repo_url: https://github.com/vatnz-dev/sops
 repo_name: vatnz-dev/sops
 edit_uri: "" #removes edit button and icon

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,3 @@ mkdocs-material==8.5.2
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects
-pillow
-cairosvg

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 mkdocs
-mkdocs-material==8.0.5
+mkdocs-material==8.5.2
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects
+pillow
+cairosvg


### PR DESCRIPTION
This bumps MkDocs Material to v8.5.2, which is a prerequisite for features like Social Cards.

To test, you will need to checkout the branch, and then re-run ` pip install -r requirements.txt`, which will update your local version. 

Note: This PR was originally for social cards integration, but it is better off to be included in a wider SOPs platform refresh, as it requires substantial changes to the back-end, and how we manage the platform.