### PR TITLE
routine: Bump MkDocs to ver 8.5.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mkdocs
-mkdocs-material==8.5.2
+mkdocs-material==8.5.10
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
Bumped MkDocs from 8.5.2 to 8.5.10. See full changelog on [MkDocs page](https://squidfunk.github.io/mkdocs-material/changelog/#8.5.10).

Major change is the updated admonitions styling. See attached image.

![image](https://user-images.githubusercontent.com/13634684/211177938-81979031-ee7d-4170-8318-547947826532.png)
