### PR TITLE
Tweak MKDocs features

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ theme:
     - navigation.tabs.sticky
     - navigation.top
     - navigation.tracking
+    - navigation.indexes
     - search.suggest
     - search.highlight
     - search.share

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ plugins:
   - git-revision-date-localized:
       type: date
   - external-markdown
+  - glightbox
 
 # Styling Front-end
 extra_css:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects
 mkdocs-embed-external-markdown
+mkdocs-glightbox


### PR DESCRIPTION
* Add lightbox support to make images clickable for a closer look
* Add navigation section index support so that when clicking on a "higher" level left-nav item, if an index page is associated it will automatically display that when clicked on. e.g., if you click on Aerodromes, there is no longer an Overview page - the Aerodromes link shows that page by default. Similarly, if you click on Class C the Overview page (which is set as the index page for that section) is displayed on click and you no longer have to manually click on Overview to show it.