### PR TITLE
OPS-100: add index support to make higher level navigation items clickable

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ theme:
     - navigation.tabs.sticky
     - navigation.top
     - navigation.tracking
+    - navigation.indexes
     - search.suggest
     - search.highlight
     - search.share


### PR DESCRIPTION
Makes section headers clickable when they have an index page defined to allow for the section headers to contain their own content and not have to have a separate second click to get to the content. See (e.g.) Aerodromes -> Class C and Class C -> NZAA section headers.