### PR TITLE
Housekeeping: MkDocs bump, add Social Cards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,4 @@ jobs:
           python-version: 3.x
       - run: pip install mkdocs-material 
       - run: pip install -r requirements.txt
-      - run: mkdocs gh-deploy --force
+      - run: mkdocs gh-deploy --force --config-file production.yml

--- a/docs/aerodromes/Class-D/index.md
+++ b/docs/aerodromes/Class-D/index.md
@@ -1,6 +1,5 @@
 ---
   title: Class D 
-
 ---
 
 Class D airspace normally applies to CTRs and CTAs surrounding regional aerodromes, such as Rotorua and Nelson.

--- a/docs/changelog/.pages
+++ b/docs/changelog/.pages
@@ -1,6 +1,7 @@
 title: Client Changelogs
 nav:
     - index.md
+    - 2023.md
     - 2022.md
     - previous.md
     - ...

--- a/docs/changelog/2022.md
+++ b/docs/changelog/2022.md
@@ -2,7 +2,8 @@
   title: 2022
 ---
 
-This page lists all of the changes that have been made to VATNZ's Controller Client data for the current year. 
+!!! info
+    This page lists all of the changes that were made to VATNZ's Controller Client data for 2022.
 
 ## AIRAC 2201
 

--- a/docs/changelog/2022.md
+++ b/docs/changelog/2022.md
@@ -1,5 +1,5 @@
 ---
-  title: 2022
+  title: All 2022 Changes
 ---
 
 !!! info

--- a/docs/changelog/2023.md
+++ b/docs/changelog/2023.md
@@ -1,5 +1,5 @@
 ---
-  title: 2023
+  title: All 2023 Changes
 ---
 
 !!! info

--- a/docs/changelog/2023.md
+++ b/docs/changelog/2023.md
@@ -1,0 +1,10 @@
+---
+  title: 2023
+---
+
+!!! info
+    This page lists all of the changes that have been made to VATNZ's Controller Client data for 2023.
+
+## AIRAC 2301
+
+{{ external_markdown('https://raw.githubusercontent.com/vatSys/new-zealand-dataset/master/.github/changelogs/2023.md', '') }}

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -1,5 +1,8 @@
 ---
-  title: Latest Changes
+  title: Latest Release
 ---
+
+!!! info
+    These are the release notes for the latest publicly available version of VATNZ's Controller Data. 
 
 {{ external_markdown('https://raw.githubusercontent.com/vatSys/new-zealand-dataset/master/.github/changelogs/2023.md', '# Latest') }}

--- a/docs/changelog/previous.md
+++ b/docs/changelog/previous.md
@@ -1,8 +1,12 @@
 ---
-  title: 2021 and previous
+  title: Historical
 ---
 
 !!! warning
-    This page is currently being modified, and is not currently the most user friendly. 
+    This page is a complete dump of all vatSys Dataset changes from Cycle 2013 to 2212. 
+
+    This page has been scraped from historical GitHub changelogs, which at the time were not intended for public consumption. As such they may not be the most helpful or user friendly to read. 
+
+    These changes also, for the most part, apply to our EuroScope releases. Changes to the EuroScope dataset before the release of the vatSys profile in late-2020 are on the VATNZ website, although unavailable to the public.
 
 {{ external_markdown('https://raw.githubusercontent.com/vatSys/new-zealand-dataset/master/.github/changelogs/2021-prev.md', '') }}

--- a/docs/contribute/contributing.md
+++ b/docs/contribute/contributing.md
@@ -20,15 +20,27 @@ To contribute, you'll need the following -
 ## Lets do it!
 
 * Fork and clone the [:fontawesome-brands-github:{: .github } -  **SOPs Project**](https://github.com/vatnz-dev/sops){target=new} - [Guide](https://docs.github.com/en/get-started/quickstart/fork-a-repo){target=new}
-* Install the following Python packages: `mkdocs-material`, `mkdocs-awesome-pages-plugin`, `mkdocs-git-revision-date-localized-plugin`, `mkdocs-redirect` and `mkdocs-glightbox`.
+* Install the following Python packages: 
+    * `mkdocs-material`
+    * `mkdocs-awesome-pages-plugin`
+    * `mkdocs-git-revision-date-localized-plugin`
+    * `mkdocs-redirect`
+    * `mkdocs-glightbox`
+    * `cairosvg`
+    * `pillow`
+* Install with this single command:
 
-!!! info
-    These packages can be installed easily through a single command:
+``` py title="Run in Command Line / Terminal"
+  pip install -r requirements.txt
+```
 
-    ``` python
-      pip install -r requirements.txt
-    ```
 
+!!! info "Cairo and Pillow dependency"
+    As a part of the social card feature, the [Pillow](https://pillow.readthedocs.io/){ target=_blank } and [Cairo Graphics](https://www.cairographics.org/){ target=_blank } dependencies were added. We bundle these into our `requirements.txt` to ensure the dependencies are installed when attempting to [test social card generation]() locally.
+
+    If you encounter any trouble:
+
+      * Install a [GTK+ runtime](https://github.com/tschoonj/GTK-for-Windows-Runtime-Environment-Installer/releases){ target=_blank } for Windows.
 
 
 * Once you've installed those, open a command line terminal, `cd` into the cloned repository folder and enter start the MkDocs service:
@@ -52,5 +64,19 @@ To contribute, you'll need the following -
     `mkdocs serve --dirtyreload`
 
 
+## Social Cards
 
+!!! warning "You do not need to test this feature!"
+    In general use, you will not need to test or utilize this feature, unless you are actively developing or changing the configuration. It is tedious to set up, and will be automatically run during the deploy workflow. 
 
+    If you **need** to test this feature, you can follow these instructions.
+
+The SOPs site uses the Social Cards feature provided by Material for MkDocs. When generating these cards locally, these cards are generated and stored in `/.cache/plugin/social`.
+
+The normal `mkdocs.yml` that maintainers will run when testing locally does not include this feature by default, and must be manually included when either building, or needing to test the plugin.
+
+* To test the plugin when testing locally: `mkdocs serve --config-file production.yml`
+
+* To include the plugin during a deploy build: `mkdocs build --config-file production.yml`
+
+`production.yml` includes an `INHERIT` function, which essentially merges the two files together for a build deployment.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,7 +38,6 @@ theme:
 
 # Plugins
 plugins:
-  - social
   - search:
       lang: en
   - awesome-pages

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 # Project Information
 site_name: VATNZ Standard Operating Procedures
-site_description: Helpful information for people flying within the virtual New Zealand FIRs.
-site_url: http://sops.vatnz.net/
+site_description: Procedures and helpful information for Controllers to use when controlling a VATNZ position on the VATSIM network.
+site_url: https://sops.vatnz.net/
 repo_url: https://github.com/vatnz-dev/sops
 repo_name: vatnz-dev/sops
 edit_uri: "" #removes edit button and icon
@@ -38,6 +38,7 @@ theme:
 
 # Plugins
 plugins:
+  - social
   - search:
       lang: en
   - awesome-pages

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,10 +18,11 @@ theme:
     - scheme: default
       toggle:
         icon: material/weather-sunny
-        name: Switch to dark mode
+        name: Go to the dark side..
     - scheme: slate
       toggle:
         icon: material/weather-night
+        name: Shine some light on this!
   features:
     - navigation.tabs
     - navigation.tabs.sticky

--- a/production.yml
+++ b/production.yml
@@ -1,0 +1,10 @@
+INHERIT: mkdocs.yml
+
+# Only include on production. In theory, this should only generate Cards when being deployed to GitHub pages, or when specified during development.
+plugins:
+  social:
+    cards_layout_options:
+      background_color: "#171e2c"
+      font_family: Manrope
+    cards_exclude:
+      - contribute/*.md

--- a/production.yml
+++ b/production.yml
@@ -5,6 +5,6 @@ plugins:
   social:
     cards_layout_options:
       background_color: "#171e2c"
-      font_family: Manrope
+      font_family: Inter
     cards_exclude:
       - contribute/*.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects
 mkdocs-embed-external-markdown
 mkdocs-glightbox
+pillow
+cairosvg

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mkdocs
-mkdocs-material==9.0.3
+mkdocs-material==9.1.15
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
- Bumps MkDocs to 9.1.15
- Implements the Social Cards feature
- Added documentation for Social Cards
- Amend workflow for Social Cards. Build workflow now deep-links with `production.yml` on deployment
- Amend a couple of page titles, as Social Cards expects a string and not an integer page title