### PR TITLE
Minor edits to enroute pages

### DIFF
--- a/docs/enroute/BAY.md
+++ b/docs/enroute/BAY.md
@@ -40,9 +40,9 @@ BAY also manages traffic into and out of HN TMA to the east. When HN TMA is offl
 
 ### GS TWR
 
-When GS TWR is offline, RAN is responsible for all functions of GS TWR, including the Procedural Tower service. 
+When GS TWR is offline, BAY is responsible for all functions of GS TWR, including the Procedural Tower service. 
 
-When responsible for GS TWR, RAN may opt to provide a radar approach service, rather than a procedural approach service. 
+When responsible for GS TWR, BAY may opt to provide a radar approach service, rather than a procedural approach service. 
 
 
 ## Coordination

--- a/docs/enroute/KAI.md
+++ b/docs/enroute/KAI.md
@@ -105,7 +105,7 @@ KAI may clear aircraft direct to the STAR's WN TMA boundary fix without coordina
 
 #### NZWB
 
-Provided that there is no conflicting KAI traffic, KAI may clear NZWB bound aircraft direct to the `ELPIT` or `OMDOX` fixes on the `JAMIE #J or #K` STARs without coordination.
+Provided that there is no conflicting NAK traffic, KAI may clear NZWB bound aircraft direct to the `ELPIT` or `OMDOX` fixes on the `JAMIE #J or #K` STARs without coordination.
 
 KAI may descend aircraft bound for NZWB to `A080` without coordination from WN TMA.
 

--- a/docs/enroute/NAK.md
+++ b/docs/enroute/NAK.md
@@ -3,6 +3,8 @@
 
 ---
 
+--8<-- "includes/abbreviations.md"
+
 ## Positions
 
 | Sector Name                     | Shortcode | Callsign             | Frequency | Login ID   |

--- a/docs/enroute/OCR.md
+++ b/docs/enroute/OCR.md
@@ -14,8 +14,8 @@
 
 OCR covers all airspace within the lateral bounds as found below. The lower limit for OCR is:
 
-  - Within 100nm AA VOR: `A095`
-  - Between 100 to 200nm AA VOR: `A135`
+  - Within 100 nm AA VOR: `A095`
+  - Between 100 and 200 nm AA VOR: `A135`
 
 When RAN, BAY or AA TMA are offline, OCR automatically inherits and assumes all responsibility for those sectors. 
 

--- a/docs/enroute/STH.md
+++ b/docs/enroute/STH.md
@@ -19,7 +19,9 @@ As CH TMA has an upper limit of `A095`, STH provides control for any aircraft ov
 
 As QN TMA has an upper limit of `FL175`, STH provides control for any aircraft overflying the QN TMA.
 
-When KAI, QN TMA, DN TWR or NV TWR is offline, STH automatically inherits and assumes responsibility for those sectors.
+When KAI or QN TMA is offline, STH automatically inherits and assumes responsibility for those sectors.
+
+When DN TWR or NV TWR is offline, STH automatically inherits the TWR and Procedural Approach services provided by those sectors. See the responsibilities sections on [DN TWR](#dn-twr) and [NV TWR](#nv-twr).
 
 When CH TMA is offline, that position is inherited by KAI. If KAI is also offline, STH automatically assumes responsibility for KAI, and therefore for CH TMA also.
 
@@ -55,13 +57,17 @@ STH shall ensure that aircraft overflying the CH TMA are no lower than `A110` wi
 
 STH shall ensure that an efficient arrival flow is managed into DN TWR's airspace. 
 
-When DN TWR is offline, the DN Procedural Tower service shall be provided by STH. When responsible for DN TWR, STH may opt to provide a radar approach service, rather than a procedural approach service.
+When DN TWR is offline, the DN Procedural Tower service shall be provided by STH. 
+
+When responsible for DN TWR, STH may opt to provide a radar approach service, rather than a procedural approach service.
 
 ### NV TWR
 
 STH shall ensure that an efficient arrival flow is managed into NV TWR's airspace. 
 
-When NV TWR is offline, the NV Procedural Tower service shall be provided by STH. When responsible for NV TWR, STH may opt to provide a radar approach service, rather than a procedural approach service.
+When NV TWR is offline, the NV Procedural Tower service shall be provided by STH. 
+
+When responsible for NV TWR, STH may opt to provide a radar approach service, rather than a procedural approach service.
 
 
 ## Coordination
@@ -82,7 +88,7 @@ STH shall ensure that aircraft have been cleared to their RFL on crossing the bo
 
 ### KAI
 
-While mostly not needed, KAI may descend aircraft to `FL190` if necessary.
+While mostly not needed, STH may descend aircraft to `FL190` if necessary.
 
 STH shall ensure that aircraft have been cleared to their RFL on crossing the boundary, with the exception of any descending traffic.
 


### PR DESCRIPTION
## Changes:
- OCR: 
   - Cleaned up Airspace definition
- BAY: 
   - Removed references to RAN in GS TWR
- NAK:
   - Add abbreviations include
- KAI:
   - Updated KAI to NAK in NZWB
- STH:
  - Aligned airspace definitions with the other sectors
  - Aligned responsibilities with the other sectors 
  - Changed KAI to STH in KAI
   
Tom L
