### PR TITLE
feat: Add GA analytics

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,9 @@ extra:
     - icon: fontawesome/brands/discord
       link: https://vatnz.net/discord
       name: VATNZ on Discord
+  analytics:
+    provider: google
+    property: ${{ secrets.SOPS_ANALYTICS_GOOGLE }}
 
 # Additional Markdown Extensions to use bundled icon sets
 markdown_extensions:


### PR DESCRIPTION
By default shouldn't inject Google Analytics on dev or non-prod sites but should inject into Prod build during the Github Build process