### PR TITLE
fix: class documentation missing

### DIFF
--- a/docs/aerodromes/index.md
+++ b/docs/aerodromes/index.md
@@ -4,10 +4,23 @@
 
 This section covers aerodrome specific procedures, separated by airspace class.
 
-## In this Section
+## Class C
 
-[Class C Aerodromes](./Class-C/index.md){ .md-button } [Class D Aerodromes](./Class-D/index.md){ .md-button }
+Class C airspace is applied to CTRs at large international aerodromes, associated CTAs, and en‑route airspace covering principal domestic air routes.
 
+In this airspace IFR and VFR traffic are separated from each other at all times. Within a CTR, IFR aircraft are separated from special VFR (operating below visual meteorological conditions) aircraft, and special VFR aircraft are  eparated from each other when visibility is less than 5 km.
+
+Where separation is not being provided, air traffic controllers are required to pass appropriate traffic information to VFR aircraft about other VFR aircraft, or special VFR aircraft when visibility is less than 5 km. VFR aircraft, however, must maintain their own separation from each other.
+
+All aircraft require an ATC clearance to be in Class C airspace.
+
+## Class D
+
+Class D airspace normally applies to CTRs and CTAs surrounding regional aerodromes, such as Rotorua and Nelson.
+
+IFR aircraft are separated from other IFR aircraft, but VFR aircraft are not separated from any IFR or other VFR aircraft. Within a CTR only, during special VFR conditions, IFR aircraft are separated from special VFR aircraft, and pecial VFR aircraft are separated from other special VFR aircraft when visibility is less than 5 km.
+
+Pilots of VFR and IFR aircraft operating within Class D airspace must use a good lookout to separate themselves from each other as ATC separation is not provided. 
 
 --8<-- "includes/abbreviations.md"
 


### PR DESCRIPTION
During the issue with the CI deploy the main Aerodrome page went AWOL so this restores this page back to what it was.