### PR TITLE
Fixes #81: Cycle 2406: Add NZCH short-STARs

### DIFF
--- a/docs/enroute/BAY.md
+++ b/docs/enroute/BAY.md
@@ -31,7 +31,7 @@ BAY is responsible for managing the flow, sequence and initial descent of East C
 BAY shall also manage the arrivals and departures into and out of any controlled or uncontrolled IFR aerodromes in its sector. This shall include issuing STARs and providing a top-down service where appropriate.
 
 !!! info
-    In the real world, BAY is heavility utilised for contingency operations when RAN sector is unavailable, with main trunk traffic overflying Lake Taupo before being sequenced for the `NOBAR` STAR into NZAA.
+    In the real world, BAY is heavility utilised for contingency operations when RAN sector is unavailable, with main trunk traffic overflying Lake Taupo before being sequenced for the `DODKU` STAR into NZAA.
 
 
 ### HN TMA
@@ -71,7 +71,7 @@ BAY may descend aircraft to `A110` without coordination from AA TMA.
 
 If a sequencing conflict is to occur, BAY shall coordinate with AA TMA as to an ideal arrival order. In the event that RAN and BAY sector traffic interfere, AA TMA shall decide the order of arrivals.
 
-BAY shall ensure that IFR aircraft crossing into AA TMA bound for NZAA are established on the `NOBAR` STAR. BAY shall not issue track shortening beyond `NOBAR` except where required by AA TMA for sequencing.
+BAY shall ensure that IFR aircraft crossing into AA TMA bound for NZAA are established on the `DODKU` STAR. BAY shall not issue track shortening beyond `DODKU` except where required by AA TMA for sequencing.
 
 ### HN TMA
 

--- a/docs/enroute/KAI.md
+++ b/docs/enroute/KAI.md
@@ -92,7 +92,7 @@ KAI may clear aircraft direct to the STAR's CH TMA boundary fix without coordina
 
 #### Short STARs - NZCH
 
-`BELEE1J` and `BELEE1K` are Short STARs into CH TMA that capture ILS 02 and ILS 20 at their intermediate fixes, `IDUBU` and `DIVSU` respectively. Controllers must co-ordinate with CH TMA or CH TWR before clearing aircraft for these arrivals, as prior planning may be required to ensure flow is maintained.
+`BELEE #J` and `BELEE #K` are Short STARs into CH TMA that capture ILS 02 and ILS 20 at their intermediate fixes, `IDUBU` and `DIVSU` respectively. Controllers must co-ordinate with CH TMA or CH TWR before clearing aircraft for these arrivals, as prior planning may be required to ensure flow is maintained.
 
 These STARs are flow control STARs, allowing controllers to sequence aircraft onto a shorter final approach. Controllers should utilise these STARs when a conflict exists at the IAF for the ILS 02/20 or if northbound or southbound arrival flows have already been established.
 

--- a/docs/enroute/KAI.md
+++ b/docs/enroute/KAI.md
@@ -79,6 +79,16 @@ KAI shall ensure that any aircraft crossing the KAI/STH boundary is established 
 
 KAI may issue STAR clearances to aircraft bound for NZCH without coordination, provided that the STAR links with the nominated runway and approach type as stated in the ATIS. A request for the use of a non-nominated approach requires agreement from both the TMA and ADC Controller.
 
+#### Short STARs
+
+`BELEE1J` and `BELEE1K` are Short STARs into CH TMA that capture ILS 02 and ILS 20 at their intermediate fixes, `IDUBU` and `DIVSU` respectively. Controllers must co-ordinate with CH TMA or CH TWR before clearing aircraft for these arrivals, as prior planning may be required to ensure flow is maintained.
+
+These STARs are flow control STARs, allowing controllers to sequence aircraft onto a shorter final approach. Controllers should utilise these STARs when a conflict exists at the IAF for the ILS 02/20 or if northbound or southbound arrival flows have already been established.
+
+These arrivals provide track shortening of **4NM** compared to the `A`/`B` arrivals.
+
+
+
 KAI may descend aircraft to `A095` without coordination from CH TMA, but should assign `A110` as the standard descent level. 
 
 If a sequencing conflict is to occur, KAI shall coordinate with CH TMA as to an ideal arrival order.

--- a/docs/enroute/KAI.md
+++ b/docs/enroute/KAI.md
@@ -96,7 +96,7 @@ KAI may clear aircraft direct to the STAR's CH TMA boundary fix without coordina
 
 These STARs are flow control STARs, allowing controllers to sequence aircraft onto a shorter final approach. Controllers should utilise these STARs when a conflict exists at the IAF for the ILS 02/20 or if northbound or southbound arrival flows have already been established.
 
-These arrivals provide track shortening of **4NM** compared to the `A`/`B` arrivals.
+These arrivals provide track shortening of **4nm** compared to the `BELEE #A`/`BELEE #B` arrivals.
 
 
 ### WN TMA

--- a/docs/enroute/KAI.md
+++ b/docs/enroute/KAI.md
@@ -79,16 +79,6 @@ KAI shall ensure that any aircraft crossing the KAI/STH boundary is established 
 
 KAI may issue STAR clearances to aircraft bound for NZCH without coordination, provided that the STAR links with the nominated runway and approach type as stated in the ATIS. A request for the use of a non-nominated approach requires agreement from both the TMA and ADC Controller.
 
-#### Short STARs
-
-`BELEE1J` and `BELEE1K` are Short STARs into CH TMA that capture ILS 02 and ILS 20 at their intermediate fixes, `IDUBU` and `DIVSU` respectively. Controllers must co-ordinate with CH TMA or CH TWR before clearing aircraft for these arrivals, as prior planning may be required to ensure flow is maintained.
-
-These STARs are flow control STARs, allowing controllers to sequence aircraft onto a shorter final approach. Controllers should utilise these STARs when a conflict exists at the IAF for the ILS 02/20 or if northbound or southbound arrival flows have already been established.
-
-These arrivals provide track shortening of **4NM** compared to the `A`/`B` arrivals.
-
-
-
 KAI may descend aircraft to `A095` without coordination from CH TMA, but should assign `A110` as the standard descent level. 
 
 If a sequencing conflict is to occur, KAI shall coordinate with CH TMA as to an ideal arrival order.
@@ -99,6 +89,15 @@ KAI may clear aircraft direct to the STAR's CH TMA boundary fix without coordina
     **KAI**: *New Zealand 677, track direct KABGO to rejoin the STAR. When ready descend A080*.
 
     **Note**: As `KABGO` sits within CH TMA's airspace, coordination would be required.
+
+#### Short STARs - NZCH
+
+`BELEE1J` and `BELEE1K` are Short STARs into CH TMA that capture ILS 02 and ILS 20 at their intermediate fixes, `IDUBU` and `DIVSU` respectively. Controllers must co-ordinate with CH TMA or CH TWR before clearing aircraft for these arrivals, as prior planning may be required to ensure flow is maintained.
+
+These STARs are flow control STARs, allowing controllers to sequence aircraft onto a shorter final approach. Controllers should utilise these STARs when a conflict exists at the IAF for the ILS 02/20 or if northbound or southbound arrival flows have already been established.
+
+These arrivals provide track shortening of **4NM** compared to the `A`/`B` arrivals.
+
 
 ### WN TMA
 

--- a/docs/enroute/KAI.md
+++ b/docs/enroute/KAI.md
@@ -90,15 +90,6 @@ KAI may clear aircraft direct to the STAR's CH TMA boundary fix without coordina
 
     **Note**: As `KABGO` sits within CH TMA's airspace, coordination would be required.
 
-#### Short STARs - NZCH
-
-`BELEE #J` and `BELEE #K` are Short STARs into CH TMA that capture ILS 02 and ILS 20 at their intermediate fixes, `IDUBU` and `DIVSU` respectively. Controllers must co-ordinate with CH TMA or CH TWR before clearing aircraft for these arrivals, as prior planning may be required to ensure flow is maintained.
-
-These STARs are flow control STARs, allowing controllers to sequence aircraft onto a shorter final approach. Controllers should utilise these STARs when a conflict exists at the IAF for the ILS 02/20 or if northbound or southbound arrival flows have already been established.
-
-These arrivals provide track shortening of **4nm** compared to the `BELEE #A`/`BELEE #B` arrivals.
-
-
 ### WN TMA
 
 KAI shall issue STAR clearances for NZWB and NZWN bound aircraft without coordination, provided that the NZWN STAR issued links with the nominated runway and approach type as stated in the ATIS. A request for use of the non-nominated approach requires agreement from both the TMA and ADC Controller.

--- a/docs/enroute/STH.md
+++ b/docs/enroute/STH.md
@@ -118,7 +118,7 @@ STH may clear aircraft direct to the STAR's CH TMA boundary without coordination
 
 #### Short STARs - NZCH
 
-`BELEE #J` and `BELEE #K` are Short STARs into CH TMA that capture ILS 02 and ILS 20 at their intermediate fixes, `IDUBU` and `DIVSU` respectively. Controllers must co-ordinate with CH TMA or CH TWR before clearing aircraft for these arrivals, as prior planning may be required to ensure flow is maintained.
+`BELEE #J` and `BELEE #K` are Short STARs into CH TMA that capture ILS 02 and ILS 20 at their intermediate fixes, `IDUBU` and `DIVSU` respectively. Controllers must co-ordinate with CH TMA before clearing aircraft for these arrivals, as prior planning may be required to ensure flow is maintained.
 
 These STARs are flow control STARs, allowing controllers to sequence aircraft onto a shorter final approach. Controllers should utilise these STARs when a conflict exists at the IAF for the ILS 02/20 or if northbound or southbound arrival flows have already been established.
 

--- a/docs/enroute/STH.md
+++ b/docs/enroute/STH.md
@@ -116,6 +116,14 @@ If a sequencing conflict is to occur, STH shall coordinate with CH TMA as to an 
 
 STH may clear aircraft direct to the STAR's CH TMA boundary without coordination, provided that they have been cleared to rejoin the STAR thereafter. Aircraft may be cleared to track direct to a fix within CH TMA's boundary with coordination, subject to the same condition.
 
+#### Short STARs - NZCH
+
+`BELEE1J` and `BELEE1K` are Short STARs into CH TMA that capture ILS 02 and ILS 20 at their intermediate fixes, `IDUBU` and `DIVSU` respectively. Controllers must co-ordinate with CH TMA or CH TWR before clearing aircraft for these arrivals, as prior planning may be required to ensure flow is maintained.
+
+These STARs are flow control STARs, allowing controllers to sequence aircraft onto a shorter final approach. Controllers should utilise these STARs when a conflict exists at the IAF for the ILS 02/20 or if northbound or southbound arrival flows have already been established.
+
+These arrivals provide track shortening of **4NM** compared to the `A`/`B` arrivals.
+
 ### DN TWR
 
 STH shall issue STARs to aircraft bound for NZDN without coordination from DN TWR. 

--- a/docs/enroute/STH.md
+++ b/docs/enroute/STH.md
@@ -118,7 +118,7 @@ STH may clear aircraft direct to the STAR's CH TMA boundary without coordination
 
 #### Short STARs - NZCH
 
-`BELEE1J` and `BELEE1K` are Short STARs into CH TMA that capture ILS 02 and ILS 20 at their intermediate fixes, `IDUBU` and `DIVSU` respectively. Controllers must co-ordinate with CH TMA or CH TWR before clearing aircraft for these arrivals, as prior planning may be required to ensure flow is maintained.
+`BELEE #J` and `BELEE #K` are Short STARs into CH TMA that capture ILS 02 and ILS 20 at their intermediate fixes, `IDUBU` and `DIVSU` respectively. Controllers must co-ordinate with CH TMA or CH TWR before clearing aircraft for these arrivals, as prior planning may be required to ensure flow is maintained.
 
 These STARs are flow control STARs, allowing controllers to sequence aircraft onto a shorter final approach. Controllers should utilise these STARs when a conflict exists at the IAF for the ILS 02/20 or if northbound or southbound arrival flows have already been established.
 


### PR DESCRIPTION
AIRAC 2406 introduces short STARs into NZCH - `BELEE1J` & `BELEE1K` which join the `ILS DME` approaches for RWY 02/20 at the intermediate fix, shortening the approaches by 4NM.

This content covers when these arrivals should be used and how controllers can co-ordinate the use of these STARs