### PR TITLE
Update font-family in home.css to include fallback options

### DIFF
--- a/overrides/assets/stylesheets/home.css
+++ b/overrides/assets/stylesheets/home.css
@@ -41,7 +41,7 @@
 
 .hero .hero-items h1 {
     color: currentColor;
-    font-family: Inter;
+    font-family: Inter, Helvetica, Arial, sans-serif;
     font-size: 40px;
     font-style: normal;
     font-weight: 600;


### PR DESCRIPTION
Refer #155.

This PR extends the font-family definition for the homepage to fall back to Helvetica, Arial, then a generic sans-serif font - in that order. 