### PR TITLE
Standardise Class C Aerodromes and Table of Contents Look and Feel Change

### DIFF
--- a/docs/aerodromes/Class-C/nzaa.md
+++ b/docs/aerodromes/Class-C/nzaa.md
@@ -16,7 +16,7 @@
 
 ### Event Only Positions
 
-!!! Danger
+!!! Danger "Important"
     The following are designated as Event Only positions, and may only be staffed during a VATNZ event where approved, or if explicitly authorised by the Operations Director.
 
 | Position Name       | Shortcode | Callsign          | Frequency | Login ID | Usage                       |
@@ -43,7 +43,7 @@ The areas of responsibility are as depicted below. The Transfer of Control Point
   <figcaption>Auckland Areas of Responsibility</figcaption>
 </figure>
 
-### Transfer of Control points
+### Transfer of Control Points
 
 | Transfer Flow      | Requirements                                                                         | Notes                                                                                  |
 | ------------------ | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
@@ -78,7 +78,7 @@ Pushback and start up clearances are managed by the Ground Controller. Controlle
 !!! example "Regional Apron: Push and Start"
     **Auckland Ground**: *"ANZ141M, push and start approved onto `B`, tail East"*
 
-#### Domestic 
+##### Domestic
 
 Aircraft pushing from Gates 20 to 22 shall push either onto `D1/D2` or `B`, depending on other traffic. Aircraft on Gates 28 to 33 shall be pushed with the nose facing towards the active runway.
 
@@ -89,7 +89,7 @@ For Gates 28 to 33, the Controller shall ensure that `B4`, `B5` and `B6` are kep
 
 Aircraft on the `C5` apron shall be instructed to push and start at their discretion, as it is not a part of the manoeuvring area but still requires a clearance.
 
-#### International 
+##### International
 
 All aircraft pushing from the International apron shall be given a tail direction instruction, and *may* be given a start location.
 
@@ -105,30 +105,8 @@ As the runway utilises high-speed exits, the Controller shall avoid using taxiwa
 
 When Runway 23L is in operation aircraft will vacate at either `A4`, `A6` or `A8`, and `A7`, `A5` or `A3` when 05R is in use.
 
-When RWY 05R is active any domestic aircraft shall be given taxi instructions via `B` and `L`. Taxiway `M` may be utilized by controllers in order to get aircraft past any queues at holding point `A9`.
+When RWY 05R is active any domestic aircraft shall be given taxi instructions via `B` and `L`. Taxiway `M` may be utilised by controllers in order to get aircraft past any queues at holding point `A9`.
 
-## Code F
-
-ICAO has classified the B747-800 and A-380 aircraft as code F aircraft (wingspan from 65 to 80 meters and a width of the main fuselage from 14 to 16 meters)
-
-Special rules apply to Code F aircraft, such as taxiway and gate restrictions.
-
-#### Code F Stand Information 
-- Contact stands for Code F aircraft are 10, 15, 16, 17 and 18.
-- Remote stands for code F aircraft are 19, 74, 75, 78 and 79.
-
-#### Code F Taxi Information
-
--  Rapid exits `A7` to `A4` inclusive are not approved for Code F use.
--  TWY `A2`, `A3`, `A8` and `A9` are available for approved A380 operators. 
-- Code F aircraft cannot taxi behind a code D, E or F aircraft holding on TWY `A1A` to TWY `A10` inclusive.
-- When a code F aircraft is on TWY `A` between `B2` and `J` a code E aircraft can operate on TWY `B`.
-- Code F aircraft may not use TWY `B` between `B2` and `B6`.
-- When 05R is in use, Code F aircraft may vacate at TWY `A3` or `A2`. 
-- When 23L is in use, Code F aircraft may vacate at TWY `A8` or `A9`. 
-
-!!! Note "Code F Arrivals"
-    Tower shall ask where the pilot is planning to vacate. TMA shall apply adequate seperation for any trailing aircraft. 
 
 #### Use of Holding Points
 
@@ -203,8 +181,57 @@ As the aircraft is off an evaluated procedure, there is a potential that an assi
     **Auckland Tower**: *"ANZ631, on departure turn right heading 190, climb five thousand"*  
     **ANZ631**: *"ANZ631, on departure turn right heading 190, climb five thousand"* 
 
+## VFR Procedures
 
-## Noise Abatement (Night STARs)
+### Arrival
+
+In order to lessen the amount of instructions given to VFR traffic, the Controller shall issue the `Ambury` VFR arrival where possible. Once the Pilot reports overhead `Little Creek`., the Controller shall integrate them with the circuit. [AIP Chart refers](https://www.aip.net.nz/assets/AIP/Aerodrome-Charts/Auckland-NZAA/NZAA_35.1_35.2.pdf){ target=new }.
+
+!!! important
+    If instructed to join via the overhead, it is the Controller's responsibility to ensure that the missed approach is protected. A non-circuit side join may be given instead.
+
+
+### Departure
+
+In order to lessen the amount of instructions given to VFR traffic, the Controller shall issue the `Ambury` VFR departure at all times - ([AIP Chart](https://www.aip.net.nz/assets/AIP/Aerodrome-Charts/Auckland-NZAA/NZAA_64.1.pdf){ target=new }). Once the Pilot reaches `Ambury Park`, the aircraft shall be handed off to UNICOM or Approach where appropriate.
+
+If a departing VFR aircraft requests to climb into controlled airspace, this shall be coordinated with Approach. The Tower Controller may amend the clearance as they see fit while the aircraft is in their Control Zone, however must be coordinated with Approach if the amendment changes their Control Area entry point.
+
+As flights to the West, North, and Northeast require a turn against the circuit direction, the Tower may approve a turn against the circuit direction.
+
+!!! example "Turn against the Circuit direction"
+    **Auckland Tower**: *"On departure a left/right turn is approved. Runway 05R/23L, cleared for takeoff"*
+
+### Helicopters
+
+Helicopter operations are frequent within Auckland CTR/C, usually operating within one of the five sectors. Tower must ensure that no VFR aircraft are present within the Instrument Sector when an aircraft is either turning onto, or established on an approach. VFR aircraft are not authorised to operate under any approach path, or within 3nm laterally of the approach path.
+
+## Special Requirements
+
+### Code F
+
+ICAO has classified the B747-800 and A-380 aircraft as code F aircraft (wingspan from 65 to 80 meters and a width of the main fuselage from 14 to 16 meters)
+
+Special rules apply to Code F aircraft, such as taxiway and gate restrictions.
+
+##### Code F Stand Information
+- Contact stands for Code F aircraft are 10, 15, 16, 17 and 18.
+- Remote stands for code F aircraft are 19, 74, 75, 78 and 79.
+
+##### Code F Taxi Information
+
+- Rapid exits `A7` to `A4` inclusive are not approved for Code F use.
+- TWY `A2`, `A3`, `A8` and `A9` are available for approved A380 operators.
+- Code F aircraft cannot taxi behind a code D, E or F aircraft holding on TWY `A1A` to TWY `A10` inclusive.
+- When a code F aircraft is on TWY `A` between `B2` and `J` a code E aircraft can operate on TWY `B`.
+- Code F aircraft may not use TWY `B` between `B2` and `B6`.
+- When 05R is in use, Code F aircraft may vacate at TWY `A3` or `A2`.
+- When 23L is in use, Code F aircraft may vacate at TWY `A8` or `A9`.
+
+!!! Note "Code F Arrivals"
+    Tower shall ask where the pilot is planning to vacate. TMA shall apply adequate separation for any trailing aircraft.
+
+### Noise Abatement (Night STARs)
 
 !!! warning "Use of Noise Abatement Operations"
     In the real world, Auckland uses noise abatement procedures from 2300 until 0600 local in order to minimise disturbances over populated areas.
@@ -213,13 +240,13 @@ As the aircraft is off an evaluated procedure, there is a potential that an assi
 
     These STARs **shall not** be used during high-traffic volumes due to the lack of separation against other routine procedures.
 
-### Use of the Preferential Runway System
+#### Use of the Preferential Runway System
 
 Use of the Preferential Runway System is not authorised and Controllers shall nominate a single runway direction for both take-off and landing.
 
-### Departures
+#### Departures
 
-#### Runway 05R
+##### Runway 05R
 
 Aircraft operating from RWY 05R shall not be taken off the SID until passing `A030`. Aircraft shall not overfly the City lower than `A050` unless established on an approach or departure path.
 
@@ -233,19 +260,19 @@ For all international departures the Controller shall issue the SID that is sugg
 | 4        | 05R    | All other SIDs |                        | Use of the `AVNAR #Q` departure shall be avoided.                                      |
 
 
-#### Runway 23L
+##### Runway 23L
 
 Aircraft operating from Rwy 23L must climb to `A030` on the extended runway centreline before turning to the right on departure. Aircraft may turn left once above `A005`.
 
 There are no limits on the issuing of SIDs for Rwy 23L.
 
-### Arrivals
+#### Arrivals
 
-#### Domestic
+##### Domestic
 
 There are no limitations on the assignment of STARs for Domestic traffic, however Controllers should avoid the issuing of RNP-linking STARs.
 
-#### International
+##### International
 
 OCR has three Noise Abatement STARs that shall be issued as first preference. If track shortening is provided, Controllers shall ensure that aircraft do not overfly the city.
 
@@ -255,30 +282,4 @@ OCR has three Noise Abatement STARs that shall be issued as first preference. If
 | 05R    | `RIKDI #N` | `KALAG` `AGREX` `TARIB` `ELPAK` `AGEDU` `IDSEM` `DABAS` `AKLOM` `OLBEX` | All                    |
 | 23L    | `TAZEY #N` | `PEBLU` `VELMO`                                                         | All                    |
 | 23L    | `LUNBI #N` |                                                                         | All                    |
-
-## VFR Procedures
-
-### Arrival
-
-In order to lessen the amount of instructions given to VFR traffic, the Controller shall issue the `Ambury` VFR arrival where possible. Once the Pilot reports overhead `Little Creek`., the Controller shall integrate them with the circuit. [AIP Chart refers](https://www.aip.net.nz/assets/AIP/Aerodrome-Charts/Auckland-NZAA/NZAA_35.1_35.2.pdf){ target=new }.
-
-!!! important
-    If instructed to join via the overhead, it is the Controller's responsibilty to ensure that the missed approach is protected. A non-circuit side join may be given instead.
-
-
-### Departure
-
-In order to lessen the amount of instructions given to VFR traffic, the Controller shall issue the `Ambury` VFR departure at all times - ([AIP Chart](https://www.aip.net.nz/assets/AIP/Aerodrome-Charts/Auckland-NZAA/NZAA_64.1.pdf){ target=new }). Once the Pilot reaches `Ambury Park`, the aircraft shall be handed off to UNICOM or Approach where appropriate. 
-
-If a departing VFR aircraft requests to climb into controlled airspace, this shall be coordinated with Approach. The Tower Controller may amend the clearance as they see fit while the aircraft is in their Control Zone, however must be coordinated with Approach if the ammendment changes their Control Area entry point.
-
-As flights to the West, North, and Northeast require a turn against the circuit direction, the Tower may approve a turn against the circuit direction.
-
-!!! example "Turn against the Circuit direction"
-    **Auckland Tower**: *"On departure a left/right turn is approved. Runway 05R/23L, cleared for takeoff"*
-
-### Helicopters
-
-Helicopter operations are frequent within Auckland CTR/C, usually operating within one of the five sectors. Tower must ensure that no VFR aircraft are present within the Instrument Sector when an aircraft is either turning onto, or established on an approach. VFR aircraft are not authorised to operate under any approach path, or within 3nm laterally of the approach path.
-
 

--- a/docs/aerodromes/Class-C/nzch.md
+++ b/docs/aerodromes/Class-C/nzch.md
@@ -16,7 +16,7 @@ title: NZCH - Christchurch
 
 ### Event Only Positions
 
-!!! Danger "Event Only Positions"
+!!! Danger "Important"
     The following are designated as Event Only positions, and may only be staffed during a VATNZ event where approved, or if explicitly authorised by the Operations Director.
 
 | Position Name               | Shortcode | Callsign                | Frequency | Login ID | Usage                       |
@@ -83,6 +83,51 @@ Pushback and startup clearances are managed by the Ground Controller. Due to the
 | 26 to 28          | Jets                | No               | **Yes**            | Twy `A`           | If Rwy 02 is active, Stand 28 shall be pushed clear of `A4`           |
 | 29 to 35          | Jets                | No               | **Yes**            | Twy `A15`         | International Stands                                                  |
 
+#### Taxiing
+
+##### Dakota Apron
+
+Dakota Apron is used exclusively by Parcel Air (APK), Airwork (AWK) and Texel Air (XLR). Aircraft utilising this apron may be instructed to start at their discretion and report for taxi.
+
+When ready for taxi, aircraft taxiing from the Dakota Apron may be instructed to cross Runway 29 and taxi via `F`, or may be given a [backtrack via Runway 29](#backtrack-via-rwy-29). A backtrack via Runway 29 is usually preferred, as it allows the Domestic ramp to continue to flow.
+
+##### Post Apron
+
+The Post Apron is on the northern side of `A4`, and is used by DHL, Qantas Freight and other freight traffic. Aircraft utilising this apron may be instructed to start at their discretion.
+
+##### Romeo Apron
+
+The Romeo Apron is a transitional apron, and is commonly used by aircraft arriving at the aerodrome without a contracted parking location, or for overflow or long-term parking. 
+
+!!! info
+    Aircraft utilising Stands R1A, R1B, and R3A stands may start on stand. Aircraft utilising Stands R1, R2 or R3 must be pushed onto `A15`.
+
+##### Antarctic Apron
+
+The Antarctic Apron is used for all military traffic, but may also be used for larger private traffic. Stands are not issued on this apron, and aircraft may start on stand.
+
+##### West of RWY 02/20
+
+Aircraft operating within the bounds of the Western Apron shall be controlled in line with [the Western Apron special conditions](#western-apron). 
+
+##### Use of RWY 29/11 as a Taxiway
+
+When RWY 29/11 is not in use Tower may delegate the use of RWY 29, south of the RWY 02/20 intersection, to Ground as a taxiway.
+
+###### Traffic crossing intersecting Runway
+
+When delegated RWY 29, the Ground Controller may authorise the aircraft to cross RWY 29 without seeking permission, or transferring that aircraft to Tower.
+
+!!! warning "When Runway 29/11 is in use"
+    The Ground Controller shall not assume crossing authority for the intersecting runway when Runway 29/11 is in use.
+
+!!! example "RTF for crossing a Runway"
+    **Christchurch Ground**: *"ANZ218, taxi holding point A6, Runway 02, via A. Cross Runway 29"*
+
+###### Backtrack via Rwy 29
+
+When delegated RWY 29, aircraft taxiing to or from the Dakota apron may be instructed to backtrack via RWY 29, avoiding taxiway `F`. Domestic prop traffic taxiing to or from the Domestic apron may also be instructed to backtrack via RWY 29 in order to avoid congestion on taxiway `F`.
+
 #### Use of Holding Points
 
 Departures may occur from any intersection, providing that it does not interfere with the use of normal exits. 
@@ -102,59 +147,6 @@ Departing prop traffic shall be issued `A4`, but may be re-issued `A3` if requir
 ##### High Performance Aircraft
 
 High performance aircraft, such as private jets or King Airs, may be issued any holding point, provided that it does not interfere with landing traffic. If a high performance aircraft is using a usual vacate route, any aircraft on approach shall be notified and instructed to roll out to the next runway vacate point.
-
-## Code F
-
-ICAO has classified the B747-800 and A-380 aircraft as code F aircraft (wingspan from 65 to 80 meters and a width of the main fuselage from 14 to 16 meters)
-
-Special rules apply to Code F aircraft, such as taxiway and gate restrictions.
-
-#### Code F Information 
-
-Code F aircraft may only use Stand 30. For taxi Code F aircraft must use TWY `A` and shall be given full length either `A2` or `A7`. 
-
-#### Dakota Apron
-
-Dakota Apron is used exclusively by Parcel Air (APK), Airwork (AWK) and Texel Air (XLR). Aircraft utilising this apron may be instructed to start at their discretion and report for taxi.
-
-When ready for taxi, aircraft taxiing from the Dakota Apron may be instructed to cross Runway 29 and taxi via `F`, or may be given a [backtrack via Runway 29](#backtrack-via-rwy-29). A backtrack via Runway 29 is usually preferred, as it allows the Domestic ramp to continue to flow.
-
-#### Post Apron
-
-The Post Apron is on the northern side of `A4`, and is used by DHL, Qantas Freight and other freight traffic. Aircraft utilising this apron may be instructed to start at their discretion.
-
-#### Romeo Apron
-
-The Romeo Apron is a transitional apron, and is commonly used by aircraft arriving at the aerodrome without a contracted parking location, or for overflow or long-term parking. 
-
-!!! info
-    Aircraft utilising Stands R1A, R1B, and R3A stands may start on stand. Aircraft utilising Stands R1, R2 or R3 must be pushed onto `A15`.
-
-#### Antarctic Apron
-
-The Antarctic Apron is used for all military traffic, but may also be used for larger private traffic. Stands are not issued on this apron, and aircraft may start on stand.
-
-#### West of RWY 02/20
-
-Aircraft operating within the bounds of the Western Apron shall be controlled in line with [the Western Apron special conditions](#western-apron). 
-
-#### Use of RWY 29/11 as a Taxiway
-
-When RWY 29/11 is not in use Tower may delegate the use of RWY 29, south of the RWY 02/20 intersection, to Ground as a taxiway.
-
-##### Traffic crossing intersecting Runway
-
-When delegated RWY 29, the Ground Controller may authorise the aircraft to cross RWY 29 without seeking permission, or transferring that aircraft to Tower.
-
-!!! warning "When Runway 29/11 is in use"
-    The Ground Controller shall not assume crossing authority for the intersecting runway when Runway 29/11 is in use.
-
-!!! example "RTF for crossing a Runway"
-    **Christchurch Ground**: *"ANZ218, taxi holding point A6, Runway 02, via A. Cross Runway 29"*
-
-##### Backtrack via Rwy 29
-
-When delegated RWY 29, aircraft taxiing to or from the Dakota apron may be instructed to backtrack via RWY 29, avoiding taxiway `F`. Domestic prop traffic taxiing to or from the Domestic apron may also be instructed to backtrack via RWY 29 in order to avoid congestion on taxiway `F`.
 
 ### Tower
 
@@ -189,7 +181,7 @@ There are no discrete prop or jet SIDs at Christchurch, and the Controller shall
 
 Where multiple departures have been assigned the `PEDMI #Q` SID, the Tower Controller may, with coordination with CH TMA, instruct the aircraft to fly a heading of 160°M and climb to `A050`. 
 
-Where a prop and jet have both been assigned the `PEDMI #Q`, the jet shall be issued the assigned heading due to its capacily to climb faster above the city.
+Where a prop and jet have both been assigned the `PEDMI #Q`, the jet shall be issued the assigned heading due to its capability to climb faster above the city.
 
 !!! example "RTF and coordination for Assigned Heading departure"
     <span class="coldline">**CH TWR** -> **CH TMA**</span>: "Successive PEDMI departures. Request ANZ631 assigned heading 160°M climbing five thousand then yours for vectors. Second in queue."  
@@ -202,8 +194,20 @@ Where a prop and jet have both been assigned the `PEDMI #Q`, the jet shall be is
 
 <figure markdown>
   ![Runway 20 manually assigned heading to the south upon takeoff](./assets/nzch-rwy20-assignedheading.png)
-  <figcaption>Manually assigned heading of 160°M, climbing to <code>A050</code>. Visualization in LittleNavMap and accurate as of AIRAC 2304.</figcaption>
+  <figcaption>Manually assigned heading of 160°M, climbing to <code>A050</code>. Visualisation in LittleNavMap and accurate as of AIRAC 2304.</figcaption>
 </figure>
+
+## Special Requirements
+
+### Code F
+
+ICAO has classified the B747-800 and A-380 aircraft as code F aircraft (wingspan from 65 to 80 meters and a width of the main fuselage from 14 to 16 meters)
+
+Special rules apply to Code F aircraft, such as taxiway and gate restrictions.
+
+##### Code F Information
+
+Code F aircraft may only use Stand 30. For taxi Code F aircraft must use TWY `A` and shall be given full length either `A2` or `A7`.
 
 ## Special Conditions
 

--- a/docs/aerodromes/Class-C/nzch.md
+++ b/docs/aerodromes/Class-C/nzch.md
@@ -209,13 +209,6 @@ Special rules apply to Code F aircraft, such as taxiway and gate restrictions.
 
 Code F aircraft may only use Stand 30. For taxi Code F aircraft must use TWY `A` and shall be given full length either `A2` or `A7`.
 
-## Special Conditions
-
-!!! warning "Section still under development"
-    This section is still under development. 
-
-    Please note that these are special conditions that deviate away from norms. In this case, where a section links here, use your best judgement in the interim.
-
 <!-- ### Use of RWY 29/11 as the Duty RWY
 
 ### Western Apron
@@ -226,8 +219,5 @@ Arriving / departing traffic from 11/29
 ### GCH Apron
 
 ## VFR Procedures -->
-=======
-!!! info "This is a work in progress!"
-    This page is currently being worked on by the team. It'll be here soon! If you want to help out, [have a look how you can help!](../../contribute/index.md)
     
 

--- a/docs/aerodromes/Class-C/nzqn.md
+++ b/docs/aerodromes/Class-C/nzqn.md
@@ -16,7 +16,7 @@ title: NZQN - Queenstown
 
 ### Event Only Positions
 
-!!! Danger
+!!! Danger "Important"
     The following are designated as Event Only positions, and may only be staffed during a VATNZ event where approved, or if explicitly authorised by the Operations Director.
 
 | Position Name             | Shortcode | Callsign              | Frequency | Login ID | Usage                       |
@@ -26,7 +26,7 @@ title: NZQN - Queenstown
 
 ## Airspace 
 
-The Queenstown CTR/C follows the lateral boundaires as shown below from `SFC` to `A075`. The CTR/C comprises of one large sector. 
+The Queenstown CTR/C follows the lateral boundaries as shown below from `SFC` to `A075`. The CTR/C comprises of one large sector. 
 
 <figure markdown>
   ![Queenstown Control Zone](./assets/nzqn-airspace.png)
@@ -35,7 +35,7 @@ The Queenstown CTR/C follows the lateral boundaires as shown below from `SFC` to
 
 ## Areas of Responsibility 
 
-The areas of responsiblility are as depicted below. 
+The areas of responsibility are as depicted below. 
 
 <figure markdown>
   ![Queenstown Areas of Responsibility](./assets/nzqn-resp.png) 
@@ -44,32 +44,34 @@ The areas of responsiblility are as depicted below.
 
 ### Transfer of Control Points
 
-| Transfer Flow       | Requirements                                                                             | Notes                                                                                    |
-| ------------------- | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| Delivery -> Ground  | Once PDC has been issued either through Voice or DCL.                                    | This is only effective if Ground is online otherwise the aircraft is transfered to Tower | 
-| Ground -> Tower     | Prior to arriving at their assigned hold, once clear of other traffic.                   | This is only effective if Ground is online                                               |
-| Tower -> Approach   | For airline traffic, when airborne. For GA, when leaving the zone, if applicable.        |                                                                                          |
+| Transfer Flow       | Requirements                                                                             | Notes                                                                                     |
+| ------------------- | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Delivery -> Ground  | Once PDC has been issued either through Voice or DCL.                                    | This is only effective if Ground is online otherwise the aircraft is transferred to Tower | 
+| Ground -> Tower     | Prior to arriving at their assigned hold, once clear of other traffic.                   | This is only effective if Ground is online                                                |
+| Tower -> Approach   | For airline traffic, when airborne. For GA, when leaving the zone, if applicable.        |                                                                                           |
 | Approach -> Tower   | When established on an instrument final, or if on an RNP approach, overhead the IAF.     |  
 | Tower -> Ground     | Once clear of the active runway.                                                         | This is only effective if Ground is online otherwise aircraft remain with Tower          |                                                                                        |
 
-## Clearance Delivery
+## Control Positions
 
-Clearances shall be issued by Queewnstown Delivery (if online) and may be given via DCL or voice.
+### Clearance Delivery
 
-## Ground 
+Clearances shall be issued by Queenstown Delivery (if online) and may be given via DCL or voice.
+
+### Ground
 
 The following only applies if Ground is online, otherwise these operations will be managed by the Tower. 
 
-### Pushback
+#### Pushback
 
 Pushback and start up clearances are managed by the Ground Controller. For pushbacks on apron areas the phraseology “Push your discretion” is used to indicate that the pushback
 is contained within an uncontrolled portion of the movement area and that ATC may not be aware of all apron activity.
 
-### Taxiing
+#### Taxiing
 
 If Ground is online taxi instructions will be issued by them, otherwise it is delegated to Tower.  
 
-### Use of Holding Points 
+#### Use of Holding Points
 
 |  Runway 23 | Runway 05  |
 | :--------: | :--------: |
@@ -77,11 +79,11 @@ If Ground is online taxi instructions will be issued by them, otherwise it is de
  
 
 !!! note
-    These assignemnts are in place to ensure departing aircraft can backtrack and line up simultaneously to arriving aircraft backtracking and vacating the active runway, increasing the overall efficieny of airfield movements.
+    These assignments are in place to ensure departing aircraft can backtrack and line up simultaneously to arriving aircraft backtracking and vacating the active runway, increasing the overall efficiency of airfield movements.
 
 If `14/32` is to be used for light aircraft, then holding points are to be used as required or if specifically requested by the pilot. 
 
-## Tower
+### Tower
 
 The Tower Controller is responsible for all arrivals and departures, plus any VFR aircraft operating within the QN CTR/C. 
 
@@ -89,29 +91,29 @@ Unless established within the aerodrome circuit, Tower must ensure that no VFR a
 
 Aircraft that have been cleared to operate in accordance with the Northbound or Southbound visual procedures are deemed to be separated from IFR arrivals on the RNP (AR) approaches, as these run East and West.
 
-## Departures
+### Departures
 
 Aircraft departures shall be managed in-line with the [Runway Operations section](../../controller-skills/separation.md#runway-operations)
 
-### SID Assignment 
+#### SID Assignment
 
-| Runway | Procedure     | Allowed A/C Catagories      | RNP-AR Required | Notes                           |
+| Runway | Procedure     | Allowed A/C Categories      | RNP-AR Required | Notes                           |
 | ------ | ------------- | --------------------------- | ----------------|-------------------------------- |
-|   05   | `ANPOV #A`    | Cat A to C                  | Yes             | **Preffered Jet Northbound**    |
+|   05   | `ANPOV #A`    | Cat A to C                  | Yes             | **Preferred Jet Northbound**    |
 |   05   | `BRIDGE #`    | Cat A to C                  | No              | Strictly Visual Procedure       |
-|   05   | `IPNOR #A`    | Cat A to C                  | Yes             | **Preffered Jet International** | 
+|   05   | `IPNOR #A`    | Cat A to C                  | Yes             | **Preferred Jet International** | 
 |   05   | `DOVMA #A`    | Cat B only                  | Yes             |                                 |
 |   05   | `GIXEL #`     | Cat A to C                  | No              | Contains a visual segment       |
 
-| Runway | Procedure     | Allowed A/C Catagories      | RNP-AR Required | Notes                           |
+| Runway | Procedure     | Allowed A/C Categories      | RNP-AR Required | Notes                           |
 | ------ | ------------- | --------------------------- | ----------------|-------------------------------- |
-|   23   | `ANPOV #B`    | Cat A to C                  | Yes             | **Preffered Jet Northbound**    |
+|   23   | `ANPOV #B`    | Cat A to C                  | Yes             | **Preferred Jet Northbound**    |
 |   23   | `FRANKTON #`  | Cat A to C                  | No              | Strictly Visual Procedure       |
-|   23   | `IPNOR #B`    | Cat A to C                  | Yes             | **Preffered Jet International** | 
+|   23   | `IPNOR #B`    | Cat A to C                  | Yes             | **Preferred Jet International** | 
 |   23   | `REDOL #B`    | Cat B only                  | Yes             |                                 | 
 |   23   | `VAPLI #`     | Cat A to C                  | No              | Contains a visual segment       |
 
-### Helicopters
+#### Helicopters
 
 Helicopter operations are very frequent within Queenstown CTR/C, usually operating outside Tower's airspace but must be managed with care. 
 

--- a/docs/aerodromes/Class-C/nzwn.md
+++ b/docs/aerodromes/Class-C/nzwn.md
@@ -16,7 +16,7 @@
 
 ### Event Only Positions
 
-!!! Danger
+!!! Danger "Important"
     The following are designated as Event Only positions, and may only be staffed during a VATNZ event where approved, or if explicitly authorised by the Operations Director.
 
 | Position Name             | Shortcode | Callsign              | Frequency | Login ID | Usage                       |
@@ -35,7 +35,7 @@ The Wellington CTR/C follows the lateral boundaries as shown below from `SFC` to
 
 ## Areas of Responsibility 
 
-The areas of responsiblility are as depicted below. 
+The areas of responsibility are as depicted below. 
 
 <figure markdown>
   ![Wellington Areas of Responsibility](./assets/nzwn-resp.png) 
@@ -65,7 +65,7 @@ As the flight time between Wellington, Nelson and Woodbourne (Blenheim) is so sh
 If online, Delivery shall confirm the STAR with Wellington TMA prior to passing to aircraft.
 
 !!! example "Clearance to Nelson"
-    **Wellington Delivery**: *"SDA333, Cleared Nelson 1 via LUBSI 2A arrival at 11,000ft, IVDAL 1Q departure, Sqauwk 5021"*
+    **Wellington Delivery**: *"SDA333, Cleared Nelson 1 via LUBSI 2A arrival at 11,000ft, IVDAL 1Q departure, Squawk 5021"*
 
 ### Ground
 
@@ -113,7 +113,7 @@ Aircraft that have been cleared to operate within the Kelburn, Somes, East, Sinc
 
 Aircraft departures shall be managed in-line with the [Runway Operations section](../../controller-skills/separation.md#runway-operations)
 
-Where possible, and where weather permits, the SIDs with visual departure segements shall be issued to small Approach Category A and B aircraft (C208, PC12), to ensure an immediate turn to their departure's IDF.
+Where possible, and where weather permits, the SIDs with visual departure segments shall be issued to small Approach Category A and B aircraft (C208, PC12), to ensure an immediate turn to their departure's IDF.
 
 !!! warning "Golden Bay Air BN-2 Aircraft"
     For the purposes of traffic separation, the Britten Norman Islander shall be classed as a Category A aircraft.
@@ -159,7 +159,7 @@ To ensure a divergent departure occurs due to traffic, WN TMA may request an air
 In order to lessen the amount of instructions given to VFR traffic, the Controller shall issue a published VFR arrival where possible. Once the Pilot reports overhead the respective VRP, the Controller shall integrate them with the circuit. [AIP Chart refers NZWN arrivals](https://www.aip.net.nz/assets/AIP/Aerodrome-Charts/Wellington-NZWN/NZWN_35.1_35.2.pdf){ target=new }.
 
 !!! important
-    If instructed to join via the overhead, it is the Controller's responsibilty to ensure that the missed approach is protected. A non-circuit side join may be given instead.
+    If instructed to join via the overhead, it is the Controller's responsibility to ensure that the missed approach is protected. A non-circuit side join may be given instead.
 
 
 ### Departure

--- a/docs/stylesheets/custom-toc.css
+++ b/docs/stylesheets/custom-toc.css
@@ -1,0 +1,9 @@
+/* Make the first-level items (top-level) bold */
+.md-nav__list > .md-nav__item > .md-nav__link {
+    font-weight: bold;
+  }
+
+  /* Make second-level items normal weight */
+  .md-nav__list > .md-nav__item > nav .md-nav__list > .md-nav__item > .md-nav__link {
+    font-weight: normal;
+  }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,10 @@ extra_css:
   - stylesheets/extra.css
   - stylesheets/admonitions.css
   - stylesheets/navigation.css
+  - stylesheets/custom-toc.css
+
+toc:
+  - toc_class: custom-toc
 
 # Extra Functions / Customizations
 extra:
@@ -100,3 +104,6 @@ markdown_extensions:
   md_in_html: {} #enables the use of image figures
   abbr: {}
   pymdownx.snippets: {}
+  toc:
+    toc_depth: 4
+


### PR DESCRIPTION
1. Code F and Noise Abatement moved under a Special Requirements section (happy to have another name recommended if that doesn't sound quite right) and this section is now the last section on the page given that they are both not quite as important as the other parts
2. ToC depth capped at 4 - it does mean some smaller headings don't show in the ToC but I think it helps keep it a bit more concise and easier to work out where to look overall
3. Borrowed/stole some CSS from VATPAC SOPs site to bold the main headings on the page as I think that also helps the eye work out where to look
4. Spelling fixed across Class C aerodrome files