### PR TITLE
fix: ensure Last Update dates on pages are accurate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,14 @@ name: ci
 on:
   push:
     branches:
-      - master
       - main
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: '3.x'
       - run: pip install -r requirements.txt
       - run: mkdocs gh-deploy --force --config-file production.yml


### PR DESCRIPTION
Currently all Last Updates on pages are the same. I think this is because by default only the last commit is checked out by Github actions and therefore the history is not available for Mkdocs to correctly put the date and there is falling back to current timestamp.

With this change it should be easier to see when the page was actually last updated.

Also remove checkout of `master` as the branch is not in use anymore.