### PR TITLE
NZTG 2026 Updates

### DIFF
--- a/docs/aerodromes/Class-D/nztg.md
+++ b/docs/aerodromes/Class-D/nztg.md
@@ -14,7 +14,7 @@
 
 ## Layout
 
-Tauranga has four gates on the main apron and is home to over 20 private hangars. Tauranga also hosts multiple flight training organisations, which provides training for fixed wing, helicopter and gliders.
+Tauranga has seven gates on the main apron and is home to over 20 private hangars. Tauranga also hosts multiple flight training organisations, which provides training for fixed wing, helicopter and gliders.
 
 Tauranga has six Runways in total. While only four are regularly used, the remainder are used when required or when special operations are in place.
 
@@ -30,12 +30,12 @@ Tauranga has six Runways in total. While only four are regularly used, the remai
 | 07 - 25           | 1825       | Bituminous |
 | 07 - 25           | 750        | Grass      |
 | 04 - 22           | 640        | Grass      |
-| 16 - 34           | 575        | Grass      |
+| 16 - 34           | 305        | Grass      |
 
 
 Sealed 07/25 is always issued to aircraft with a gross weight of 5500kg or more, and can be issued to smaller aircraft on request. Gliders & helicopters are not permitted to use the sealed runway.
 
-Grass 25/07 is always issued to light aircraft with a gross weight of 5500kg or less and cannot be issued to Category B/C/D aircraft.
+Grass 07/25 is always issued to light aircraft with a gross weight of 5500kg or less and cannot be issued to Category B/C/D aircraft.
 
 !!! info "Grass 04/22 Glider Operations Only"
         The Airport Company has an agreement with the Gliding Club prohibiting use of Grass 04/22 for aircraft other than gliders and tow planes.
@@ -72,11 +72,14 @@ With permission from Tauranga Tower, traffic are permitted to conduct a standard
 
 ## Runway 07
 
-All arrivals terminate at `RUSTA` or `MORTA`, which are the IAF(s) for the RNP approach.
+All STARs terminate at `RUSTA` or `MORTA`, which are the IAF(s) for the RNP approach.
 
 ### Missed Approach
 
-In the event of a missed approach, aicraft should be instructed to carry out the published missed approach procedure. This will have the aircraft climbing to 2000 feet, turning direct to `LETGU`, before holding at `RUSTA` 5000 feet or above. Aircrft can then be re-cleared for the RNP approach, or cleared a visual approach, should the conditions be suitable.
+In the event of a missed approach, aicraft should be instructed to carry out the published missed approach procedure. This will have the aircraft climbing to 3000 feet, turning direct to `TORUV`, before holding at `RUSTA` 5000 feet or above. Aircrft can then be re-cleared for the RNP approach, or cleared a visual approach, should the conditions be suitable.
+
+!!! note "Arriving aircraft"
+    Aircraft inbound for an approach are permitted to descend to 3000 feet, at the discretion of the controller.
 
 ## Runway 25
 
@@ -86,7 +89,10 @@ All arrivals terminate at `UBSET ` or `TODAN`, which are the IAF(s) for the RNP 
 
 ### Missed Approach
 
-In the event of a missed approach, aicraft should be instructed to carry out the published missed approach procedure. This will have the aircraft climbing to 2000 feet, turning direct to `LETGU`, before holding at `UBSET` at 4000 feet or above. Aircrft can then be re-cleared for the RNP approach, or cleared a visual approach, should the conditions be suitable.
+In the event of a missed approach, aicraft should be instructed to carry out the published missed approach procedure. This will have the aircraft climbing to 2000 feet, turning direct to `OLNUG`, before holding at `UBSET` at 4000 feet or above. Aircrft can then be re-cleared for the RNP approach, or cleared a visual approach, should the conditions be suitable.
+
+!!! note "Arriving aircraft"
+    Aircraft inbound for an approach are permitted to descend to 3000 feet, at the discretion of the controller.
 
 # Departures
 
@@ -124,7 +130,9 @@ There are various intermediate holding points specifically for the grass runways
         
 #### Sealed Hold Short Points
 
-- Sealed 07/25 (from the Main Apron) - `A2` or `A3`
+- Sealed 07/25 (from the Main Apron) - `A3` or `A2`
+
+- Sealed 07/25 (to the Main Apron) - `A1` or to the gate, when explicit clearance to cross the grass runway has been given.
 
 - Sealed 07 (light aircraft) - `W1` or `W2`
 

--- a/docs/aerodromes/Class-D/nztg.md
+++ b/docs/aerodromes/Class-D/nztg.md
@@ -76,7 +76,7 @@ All STARs terminate at `RUSTA` or `MORTA`, which are the IAF(s) for the RNP appr
 
 ### Missed Approach
 
-In the event of a missed approach, aicraft should be instructed to carry out the published missed approach procedure. This will have the aircraft climbing to 3000 feet, turning direct to `TORUV`, before holding at `RUSTA` 5000 feet or above. Aircrft can then be re-cleared for the RNP approach, or cleared a visual approach, should the conditions be suitable.
+In the event of a missed approach, aircraft should be instructed to carry out the published missed approach procedure. This will have the aircraft climbing to 3000 feet, turning direct to `TORUV`, before holding at `RUSTA` 5000 feet or above. Aircrft can then be re-cleared for the RNP approach, or cleared a visual approach, should the conditions be suitable.
 
 !!! note "Arriving aircraft"
     Aircraft inbound for an approach are permitted to descend to 3000 feet, at the discretion of the controller.
@@ -89,7 +89,7 @@ All STARs terminate at `UBSET ` or `TODAN`, which are the IAF(s) for the RNP app
 
 ### Missed Approach
 
-In the event of a missed approach, aicraft should be instructed to carry out the published missed approach procedure. This will have the aircraft climbing to 2000 feet, turning direct to `OLNUG`, before holding at `UBSET` at 4000 feet or above. Aircrft can then be re-cleared for the RNP approach, or cleared a visual approach, should the conditions be suitable.
+In the event of a missed approach, aircraft should be instructed to carry out the published missed approach procedure. This will have the aircraft climbing to 2000 feet, turning direct to `OLNUG`, before holding at `UBSET` at 4000 feet or above. Aircrft can then be re-cleared for the RNP approach, or cleared a visual approach, should the conditions be suitable.
 
 !!! note "Arriving aircraft"
     Aircraft inbound for an approach are permitted to descend to 3000 feet, at the discretion of the controller.

--- a/docs/aerodromes/Class-D/nztg.md
+++ b/docs/aerodromes/Class-D/nztg.md
@@ -85,7 +85,7 @@ In the event of a missed approach, aicraft should be instructed to carry out the
 
 ### Approaches
 
-All arrivals terminate at `UBSET ` or `TODAN`, which are the IAF(s) for the RNP approach.
+All STARs terminate at `UBSET ` or `TODAN`, which are the IAF(s) for the RNP approach.
 
 ### Missed Approach
 


### PR DESCRIPTION
This PR brings the NZTG page in-line with current layout and procedural changes for 2026. 

- Corrected gates
- Corrected Grass 16/34 length
- Corrected RNP missed approach waypoint names.
- Added minor notes for arrival holding